### PR TITLE
Fix for Wagtail >=2.11

### DIFF
--- a/wagtailcolourpicker/wagtail_hooks.py
+++ b/wagtailcolourpicker/wagtail_hooks.py
@@ -1,11 +1,5 @@
-try:
-    # Django 2
-    from django.contrib.staticfiles.templatetags.staticfiles import static
-except ModuleNotFoundError:
-    # Django 3
-    from django.templatetags.static import static
 from django.urls import reverse, path, include
-from django.utils.html import format_html_join, format_html
+from django.utils.html import format_html
 from django.utils.translation import ugettext as _
 
 from wagtail.admin.rich_text.editors.draftail import features as draftail_features
@@ -23,32 +17,9 @@ def register_admin_urls():
     ]
 
 
-@hooks.register('insert_editor_css')
-def editor_css():
-    css_files = [
-        'colourpicker/css/colourpicker.css',
-    ]
-    css_includes = format_html_join(
-        '\n',
-        '<link rel="stylesheet" href="{0}">',
-        ((static(filename), ) for filename in css_files)
-    )
-    return css_includes
-
-
 @hooks.register('insert_editor_js')
 def insert_editor_js():
-    js_files = [
-        # We require this file here to make sure it is loaded before the other.
-        'wagtailadmin/js/draftail.js',
-        'colourpicker/js/colourpicker.js',
-    ]
-    js_includes = format_html_join(
-        '\n',
-        '<script src="{0}"></script>',
-        ((static(filename), ) for filename in js_files)
-    )
-    js_includes += format_html(
+    js_includes = format_html(
         "<script>window.chooserUrls.colourChooser = '{0}';</script>",
         reverse('wagtailcolourpicker:chooser')
     )
@@ -75,7 +46,13 @@ def register_textcolour_feature(features):
         feature_name,
         draftail_features.EntityFeature(
             control,
-            js=['colourpicker/js/chooser.js']
+            js=[
+                'colourpicker/js/chooser.js',
+                'colourpicker/js/colourpicker.js',
+            ],
+            css={
+                'all': ['colourpicker/css/colourpicker.css'],
+            }
         )
     )
 


### PR DESCRIPTION
As documented at https://github.com/wagtail/wagtail/issues/6724, inserting `wagtailadmin/js/draftail.js` via the insert_editor_js hook meant that it got included twice from Wagtail 2.7 onward, and this broke in 2.11 following a change to the webpack config. Update this so that the JS (and CSS) gets inserted as part of the Draftail plugin definition, rather than through the insert_editor_js hook.